### PR TITLE
add titiler endpoint from cdk-pgstac construct

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-STAGE='dev'
-STAC_API_INTEGRATION_API_ARN=''
+STAGE='test'
+DB_ALLOCATED_STORAGE=20
+STAC_API_INTEGRATION_API_ARN='arn:aws:execute-api:us-west-2:532321095167:hqprpfkrqg/*/$default'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
     environment: "${{ github.event.inputs.deployment_environment }}"
     
     steps:
+
     - name: Checkout repository
       uses: actions/checkout@v2
 
@@ -33,7 +34,9 @@ jobs:
         role-session-name: MAAP-CDK-pgstac-deploy
 
     - name: Install deployment dependencies
-      run: npm install
+      run: | 
+        npm install
+        curl -o node_modules/cdk-pgstac/lib/titiler-pgstac-api/runtime/Dockerfile https://raw.githubusercontent.com/developmentseed/cdk-pgstac/titiler-pgstac-dockerfile-copy-syntax/lib/titiler-pgstac-api/runtime/Dockerfile
 
 
     - name: Import stacks variables to github output

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -17,6 +17,7 @@ import {
   TitilerPgstacApiLambda
 } from "cdk-pgstac";
 import { readFileSync } from "fs";
+import { safeLoad } from "js-yaml";
 
 export class PgStacInfra extends Stack {
   constructor(scope: Construct, id: string, props: Props) {
@@ -58,8 +59,9 @@ export class PgStacInfra extends Stack {
     });
 
 
-    const buckets = ["nasa-maap-data-store"];
-
+    const fileContents = readFileSync('../titiler_buckets.yaml', 'utf8')
+    const buckets = safeLoad(fileContents);
+    
     new TitilerPgstacApiLambda(this, "titiler-pgstac-api", {
       apiEnv: {
         NAME: `MAAP titiler pgstac API (${stage})`,

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -12,6 +12,7 @@ import {
   PgStacApiLambda,
   PgStacDatabase,
   StacIngestor,
+  TitilerPgstacApiLambda
 } from "cdk-pgstac";
 import { readFileSync } from "fs";
 
@@ -52,6 +53,22 @@ export class PgStacInfra extends Stack {
       db,
       dbSecret: pgstacSecret,
       subnetSelection: apiSubnetSelection,
+    });
+
+
+    const buckets = ["nasa-maap-data-store"];
+
+    new TitilerPgstacApiLambda(this, "titiler-pgstac-api", {
+      apiEnv: {
+        NAME: `MAAP titiler pgstac API (${stage})`,
+        VERSION: version,
+        DESCRIPTION: "titiler pgstac API for the MAAP STAC system.",
+      },
+      vpc,
+      db,
+      dbSecret: pgstacSecret,
+      subnetSelection: apiSubnetSelection,
+      buckets: buckets,
     });
 
     new BastionHost(this, "bastion-host", {

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -17,7 +17,7 @@ import {
   TitilerPgstacApiLambda
 } from "cdk-pgstac";
 import { readFileSync } from "fs";
-import { safeLoad } from "js-yaml";
+import { load } from "js-yaml";
 
 export class PgStacInfra extends Stack {
   constructor(scope: Construct, id: string, props: Props) {
@@ -60,7 +60,7 @@ export class PgStacInfra extends Stack {
 
 
     const fileContents = readFileSync('../titiler_buckets.yaml', 'utf8')
-    const buckets = safeLoad(fileContents);
+    const buckets = load(fileContents);
     
     new TitilerPgstacApiLambda(this, "titiler-pgstac-api", {
       apiEnv: {

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -60,8 +60,8 @@ export class PgStacInfra extends Stack {
 
 
     const fileContents = readFileSync('../titiler_buckets.yaml', 'utf8')
-    const buckets = load(fileContents);
-    
+    const buckets = load(fileContents) as string[];
+
     new TitilerPgstacApiLambda(this, "titiler-pgstac-api", {
       apiEnv: {
         NAME: `MAAP titiler pgstac API (${stage})`,

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -23,7 +23,7 @@ export class PgStacInfra extends Stack {
   constructor(scope: Construct, id: string, props: Props) {
     super(scope, id, props);
 
-    const { vpc, stage, version, jwksUrl, dataAccessRoleArn, allocatedStorage} = props;
+    const { vpc, stage, version, jwksUrl, dataAccessRoleArn, allocatedStorage, titilerBucketsPath} = props;
 
     const { db, pgstacSecret } = new PgStacDatabase(this, "pgstac-db", {
       vpc,
@@ -59,7 +59,7 @@ export class PgStacInfra extends Stack {
     });
 
 
-    const fileContents = readFileSync('../titiler_buckets.yaml', 'utf8')
+    const fileContents = readFileSync(titilerBucketsPath, 'utf8')
     const buckets = load(fileContents) as string[];
 
     new TitilerPgstacApiLambda(this, "titiler-pgstac-api", {
@@ -169,5 +169,10 @@ export interface Props extends StackProps {
    * allocated storage for pgstac database
    */
   allocatedStorage: number;
+
+  /**
+   * yaml file containing the list of buckets the titiler lambda should be granted access to
+   */
+  titilerBucketsPath: string;
 }
         

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -34,5 +34,6 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   bastionHostCreateElasticIp: stage === "prod",
   dataAccessRoleArn: dataAccessRoleArn,
   stacApiIntegrationApiArn: stacApiIntegrationApiArn,
-  allocatedStorage: dbAllocatedStorage
+  allocatedStorage: dbAllocatedStorage,
+  titilerBucketsPath: "./titiler_buckets.yaml"
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "^2.45.0",
-        "cdk-pgstac": "4.1.0",
+        "cdk-pgstac": "4.2.1",
         "constructs": "^10.1.113",
         "source-map-support": "^0.5.16"
       },
@@ -1961,9 +1961,9 @@
       }
     },
     "node_modules/cdk-pgstac": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cdk-pgstac/-/cdk-pgstac-4.1.0.tgz",
-      "integrity": "sha512-/rHyRIAALY9aVRcu+lAkaGeqsORKv33yP+lmBdSfbDoIeQcmcSomOEP2slrrcUj2gElIdH+zF7nau2cCbG9NgQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cdk-pgstac/-/cdk-pgstac-4.2.1.tgz",
+      "integrity": "sha512-tfilhKJIHgHPWQW9StA/AkqPk0IPGidshMeXwzEKG+m/9wXAKeo8auTTGUjZQlKvT8H4NqxFNqvjRD+A9nzjPg==",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.47.0-alpha.0",
         "@aws-cdk/aws-lambda-python-alpha": "^2.47.0-alpha.0",
@@ -8134,9 +8134,9 @@
       }
     },
     "cdk-pgstac": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cdk-pgstac/-/cdk-pgstac-4.1.0.tgz",
-      "integrity": "sha512-/rHyRIAALY9aVRcu+lAkaGeqsORKv33yP+lmBdSfbDoIeQcmcSomOEP2slrrcUj2gElIdH+zF7nau2cCbG9NgQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cdk-pgstac/-/cdk-pgstac-4.2.1.tgz",
+      "integrity": "sha512-tfilhKJIHgHPWQW9StA/AkqPk0IPGidshMeXwzEKG+m/9wXAKeo8auTTGUjZQlKvT8H4NqxFNqvjRD+A9nzjPg==",
       "requires": {
         "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.47.0-alpha.0",
         "@aws-cdk/aws-lambda-python-alpha": "^2.47.0-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
       },
       "devDependencies": {
         "@types/jest": "^26.0.10",
+        "@types/js-yaml": "4.0.5",
         "@types/node": "10.17.27",
         "aws-cdk": "^2.81.0",
         "jest": "^26.4.2",
+        "js-yaml": "^4.1.0",
         "ts-jest": "^26.2.0",
         "ts-node": "^9.0.0",
         "typescript": "~3.9.7"
@@ -647,6 +649,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -1048,6 +1072,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "10.17.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
@@ -1207,13 +1237,10 @@
       "dev": true
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -4003,13 +4030,12 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -7107,6 +7133,27 @@
         "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "@istanbuljs/schema": {
@@ -7462,6 +7509,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+      "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.17.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
@@ -7587,13 +7640,10 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -9694,13 +9744,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsdom": {

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "cdk:watch": "cdk watch --all"
   },
   "devDependencies": {
+    "@types/js-yaml": "4.0.5",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "aws-cdk": "^2.81.0",
     "jest": "^26.4.2",
+    "js-yaml": "^4.1.0",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"

--- a/titiler_buckets.yaml
+++ b/titiler_buckets.yaml
@@ -1,0 +1,2 @@
+# list of s3 buckets the titiler lambda will be granted access to
+- nasa-maap-data-store


### PR DESCRIPTION
Adds a `titiler-pgstac` construct for mosaics built from and saved directly to the pgstac database, with a lambda exposed on an HTTP API. I simply import the construct developed here https://github.com/developmentseed/cdk-pgstac/pull/42. I deployed to `test` and the tiler API health checks pass (they check the connection to the pgstac database). 

Since the latter is not yet released, for now I deployed with a local build of cdk-pgstac (the setup for the local build is not showing up in the diff -- I will simply bump the cdk-pgstac version in the `package.json` file here once the release is made). The reason I did not wait for the release is that it might take some time for people to review my PR. 

Things to note : 

- [x] the lambda is deployed in the same VPC and subnet as the database
- [ ] I modified the lambda role policies to grant it access to `nasa-maap-data-store` (see the `buckets` parameter in the diff). Is there any other bucket we need this lambda to have access to ? 