### PR TITLE
decrease database storage allocation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,12 @@ on:
       deployment_environment:
         description: 'environment'
         required: true
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     environment: "${{ github.event.inputs.deployment_environment }}"
+    
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -47,6 +49,7 @@ jobs:
         STAC_API_INTEGRATION_API_ARN: ${{ vars.STAC_API_INTEGRATION_API_ARN }}
         JWKS_URL: ${{ steps.import-stacks-vars-to-output.outputs.JWKS_URL }}
         DATA_ACCESS_ROLE_ARN: ${{ steps.import-stacks-vars-to-output.outputs.DATA_ACCESS_ROLE_ARN }}
+        DB_ALLOCATED_STORAGE: ${{ vars.DB_ALLOCATED_STORAGE }}
       run: |
         npm install -g aws-cdk
         cdk deploy --all --require-approval never

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -33,7 +33,8 @@ export class PgStacInfra extends Stack {
           ? ec2.SubnetType.PUBLIC
           : ec2.SubnetType.PRIVATE_ISOLATED,
       },
-      allocatedStorage: 1024,
+      // set allocated stoarge to 20GB if stage is test, otherwise 50GB
+      allocatedStorage: stage === "test" ? 20 : 50,
       // set instance type to t3.micro if stage is test, otherwise t3.small
       instanceType: stage === "test" ? ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO) : ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.SMALL),
     });

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -21,7 +21,7 @@ export class PgStacInfra extends Stack {
   constructor(scope: Construct, id: string, props: Props) {
     super(scope, id, props);
 
-    const { vpc, stage, version, jwksUrl, dataAccessRoleArn} = props;
+    const { vpc, stage, version, jwksUrl, dataAccessRoleArn, allocatedStorage} = props;
 
     const { db, pgstacSecret } = new PgStacDatabase(this, "pgstac-db", {
       vpc,
@@ -33,8 +33,7 @@ export class PgStacInfra extends Stack {
           ? ec2.SubnetType.PUBLIC
           : ec2.SubnetType.PRIVATE_ISOLATED,
       },
-      // set allocated stoarge to 20GB if stage is test, otherwise 50GB
-      allocatedStorage: stage === "test" ? 20 : 50,
+      allocatedStorage: allocatedStorage,
       // set instance type to t3.micro if stage is test, otherwise t3.small
       instanceType: stage === "test" ? ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO) : ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.SMALL),
     });
@@ -147,5 +146,10 @@ export interface Props extends StackProps {
    * STAC API api gateway source ARN to be granted STAC API lambda invoke permission.
    */
   stacApiIntegrationApiArn: string;
+
+  /**
+   * allocated storage for pgstac database
+   */
+  allocatedStorage: number;
 }
         

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -5,7 +5,7 @@ import * as cdk from "aws-cdk-lib";
 import { Vpc } from "./Vpc";
 import { Config } from "./config";
 import { PgStacInfra } from "./PgStacInfra";
-const { stage, version, buildStackName, tags, jwksUrl, dataAccessRoleArn, stacApiIntegrationApiArn } =
+const { stage, version, buildStackName, tags, jwksUrl, dataAccessRoleArn, stacApiIntegrationApiArn, dbAllocatedStorage } =
   new Config();
 
 export const app = new cdk.App({});
@@ -34,4 +34,5 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   bastionHostCreateElasticIp: stage === "prod",
   dataAccessRoleArn: dataAccessRoleArn,
   stacApiIntegrationApiArn: stacApiIntegrationApiArn,
+  allocatedStorage: dbAllocatedStorage
 });

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -5,6 +5,7 @@ export class Config {
   readonly jwksUrl: string;
   readonly dataAccessRoleArn: string;
   readonly stacApiIntegrationApiArn: string;
+  readonly dbAllocatedStorage: number;
 
   constructor() {
     if (!process.env.STAGE) throw Error("Must provide STAGE");
@@ -20,6 +21,8 @@ export class Config {
     this.dataAccessRoleArn = process.env.DATA_ACCESS_ROLE_ARN!;
     if (!process.env.STAC_API_INTEGRATION_API_ARN) throw Error("Must provide STAC_API_INTEGRATION_API_ARN");
     this.stacApiIntegrationApiArn = process.env.STAC_API_INTEGRATION_API_ARN!;
+    if (!process.env.DB_ALLOCATED_STORAGE) throw Error("Must provide DB_ALLOCATED_STORAGE");
+    this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.45.0",
-    "cdk-pgstac": "4.1.0",
+    "cdk-pgstac": "4.2.1",
     "constructs": "^10.1.113",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
The allocated storage for the RDS instance was 1TiB by default. 

We're not using even a fraction of this. Changed to 20GiB for test and 50GiB for dev (kind of arbitrary...). 

Caveats : 

1. I am not sure these numbers are even going to work (I guess AWS allows only a limited set of options?).
2. The dev database is already up and running and it's not possible to decrease the storage allocated after the fact. Would require recreating the database and doing a data migration. 

We would at least use this for the redeployment of the test database (which is not deployed currently -- we would deploy it after this PR is merged).

@jjfrench @omshinde, could you also take a look at `.github/workflows/deploy.yaml` ? I added this in the previous PR that was merged to `main` without a review. The reason I did it was that, to be able to test it properly I _had_ to have the YAML flie in main otherwise the action wouldn't show up. So, I am requesting a review of this workflow here. Thank you ! 