### PR TITLE
Add git related tags to CDK stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,9 @@ jobs:
         JWKS_URL: ${{ steps.import-stacks-vars-to-output.outputs.JWKS_URL }}
         DATA_ACCESS_ROLE_ARN: ${{ steps.import-stacks-vars-to-output.outputs.DATA_ACCESS_ROLE_ARN }}
         DB_ALLOCATED_STORAGE: ${{ vars.DB_ALLOCATED_STORAGE }}
+        GIT_REPOSITORY: ${{ github.repository}}
+        COMMIT_SHA: ${{ github.sha }}
+        AUTHOR: ${{ github.actor }}
       run: |
         npm install -g aws-cdk
         cdk deploy --all --require-approval never

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -12,7 +12,10 @@ export class Config {
     this.stage = process.env.STAGE;
     this.version = process.env.npm_package_version!; // Set by node.js
     this.tags = {
-      version: this.version,
+      project: "MAAP",
+      author: String(process.env.AUTHOR),
+      gitCommit : String(process.env.COMMIT_SHA),
+      gitRepository: String(process.env.GIT_REPOSITORY),
       stage: this.stage,
     };
     if (!process.env.JWKS_URL) throw Error("Must provide JWKS_URL");

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,8 +13,6 @@ echo "Environment variables set:"
 echo "=========================="
 echo "JWKS_URL: $JWKS_URL"
 echo "DATA_ACCESS_ROLE_ARN: $DATA_ACCESS_ROLE_ARN"
-echo "STAGE: $STAGE"
-echo "STAC_API_INTEGRATION_API_ARN: $STAC_API_INTEGRATION_API_ARN"
 echo "=========================="
 
 # prompt user to continue. If yes, continue. If no, exit.


### PR DESCRIPTION
Added the following tags to the maap-cdk-pgstac stack to make it easier to know what the stack was deployed from. With this, if someone in the future other than the person who made the deployment discovers the stack on the AWS console, it's going to be easier to identify the repo and the version of the repo from which the deployment was operated. 

- git repository where the CDK code is contained
- commit sha 
- author 

These are passed in the action workflow yaml. 

Minor : I modified a print statement in the `deploy.sh` script, which should be used for manual deployment. Instead of printing all the environment variables required for the stack (one should look at `config.ts` to know what's required), I am just printing what's imported using the AWS CLI.